### PR TITLE
New Feature & Small Changes: Discord Role Checking, More freedom on identifier checking

### DIFF
--- a/config/server.lua
+++ b/config/server.lua
@@ -13,8 +13,10 @@ return {
         }
     },
 
-    -- List of whitelisted player identifiers (license or license2).
+    -- List of whitelisted player identifiers has to follow the following templates.
     allowedIdentifiers = {
+        -- 'license:a84c129fbad317b8d5f6c7e18f0248abc9d5e13f'   -- Example license identifier
+        -- 'discord:728153984225673519'                         -- Example discord identifier
     },
 
     discord = {

--- a/config/server.lua
+++ b/config/server.lua
@@ -2,37 +2,38 @@ return {
     lockdown = {
         enabled = true,
 
-        --[[ Should it kick all the users or only thos not whitelisted ]]
-        kickAllWhenEnabled = true,
+        -- true: Kick all players during lockdown, false: Keep whitelisted players
+        kickAllPlayers = true,
 
         from = { -- Time when the server closes (24-hour format)
             hour = 3,
-            minute = 16
+            minute = 15
         },
 
         to = { -- Time when the server opens (24-hour format)
             hour = 17,
-            minute = 0,
+            minute = 30,
         }
     },
 
     -- List of whitelisted player identifiers has to follow the following templates.
     allowedIdentifiers = {
         -- 'license:a84c129fbad317b8d5f6c7e18f0248abc9d5e13f'   -- Example license identifier
-        -- 'discord:728153984225673519'                         -- Example discord identifier
+        -- 'discord:294990611633799180'                         -- Example discord identifier
     },
 
+    -- Optional Discord role check for semi-whitelist servers (thanks @Maximus7474!)
     discord = {
-        --[[ Discord Bot Token: https://discord.com/developers/applications ]]
-        --[[ string or false ]]
+        -- Discord Bot Token: https://discord.com/developers/applications
+        -- Set to false to disable the Discord role check feature
         token = false,
 
-        --[[ Guild Identifier ]]
+        -- Guild Identifier
         guildId = '',
 
-        --[[ Guild Role Identifiers ]]
+        -- List of allowed role identifiers
         allowedRoles = {
-            ''
+            -- '892853647950618675'                             -- Example role identifier
         }
     }
 }

--- a/config/server.lua
+++ b/config/server.lua
@@ -15,6 +15,19 @@ return {
 
     -- List of whitelisted player identifiers (license or license2).
     allowedIdentifiers = {
-        -- 'license:999a406ddec315d7c9e4b5f16e230f9ace6e09c6' -- Example license identifier
     },
+
+    discord = {
+        --[[ Discord Bot Token: https://discord.com/developers/applications ]]
+        --[[ string or false ]]
+        token = false,
+
+        --[[ Guild Identifier ]]
+        guildId = '',
+
+        --[[ Guild Role Identifiers ]]
+        allowedRoles = {
+            ''
+        }
+    }
 }

--- a/config/server.lua
+++ b/config/server.lua
@@ -2,6 +2,9 @@ return {
     lockdown = {
         enabled = true,
 
+        --[[ Should it kick all the users or only thos not whitelisted ]]
+        kickAllWhenEnabled = true,
+
         from = { -- Time when the server closes (24-hour format)
             hour = 3,
             minute = 16

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -13,6 +13,8 @@ shared_script '@ox_lib/init.lua'
 
 server_script 'server/main.lua'
 
+server_only 'yes'
+
 ox_libs {
 	'cron',
 	'locale',

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -13,11 +13,6 @@ shared_script '@ox_lib/init.lua'
 
 server_script 'server/main.lua'
 
-files {
-    'config/server.lua',
-	'locales/*.json',
-}
-
 ox_libs {
 	'cron',
 	'locale',

--- a/server/main.lua
+++ b/server/main.lua
@@ -54,7 +54,7 @@ AddStateBagChangeHandler('serverLockdown', 'global', function(_, _, value)
         for _, playerId in ipairs(GetPlayers()) do
             local isWhitelisted = utils.IsWhitelisted(source)
 
-            if not isWhitelisted then
+            if not isWhitelisted or config.lockdown.kickAllWhenEnabled then
                 DropPlayer(playerId, locale('kick_message', To.hour, To.minute))
             end
         end

--- a/server/main.lua
+++ b/server/main.lua
@@ -23,7 +23,7 @@ AddEventHandler('playerConnecting', function(name, _, deferrals)
         deferrals.update(locale('checking_lockdown', name))
 
         if not GlobalState.serverLockdown then
-            deferrals.done()
+            return deferrals.done()
         end
 
         local isWhitelisted = utils.IsWhitelisted(source)
@@ -52,9 +52,9 @@ AddStateBagChangeHandler('serverLockdown', 'global', function(_, _, value)
         lib.print.info("Closing the server..")
 
         for _, playerId in ipairs(GetPlayers()) do
-            local isWhitelisted = utils.IsWhitelisted(source)
+            local isWhitelisted = utils.IsWhitelisted(playerId)
 
-            if not isWhitelisted or config.lockdown.kickAllWhenEnabled then
+            if not isWhitelisted or config.lockdown.kickAllPlayers then
                 DropPlayer(playerId, locale('kick_message', To.hour, To.minute))
             end
         end

--- a/server/utils.lua
+++ b/server/utils.lua
@@ -1,0 +1,55 @@
+local Utils = {}
+local config = require 'config.server'
+
+local function IsDiscordWhitelisted(source)
+    if type(config.discord.token) ~= 'string' or #config.discord.token < 60 then return false end
+
+    local discordId
+    for _, identifier in pairs(GetPlayerIdentifiers(source)) do
+        if string.match(identifier, "^discord:") then
+            discordId = string.sub(identifier, 9)
+            break
+        end
+    end
+
+    if not discordId then return false end
+
+    local hasRole = promise.new()
+    PerformHttpRequest(('https://discord.com/api/v8/guilds/%s/members/%s'):format(config.discord.guildId, discordId), function(err, data, headers)
+        if data then 
+            local discordData = json.decode(data)
+
+            for _,role in pairs(discordData.roles) do
+                if lib.table.contains(config.discord.allowedRoles, role) then
+                    hasRole:resolve(true)
+                    return
+                end
+            end
+
+            hasRole:resolve(false)
+        else
+            hasRole:resolve(false)
+        end
+    end, 'GET', '', { ['Content-Type'] = 'application/json', ['Authorization'] = ('Bot %s'):format(config.discord.token) })
+
+    return Citizen.Await(hasRole)
+end
+
+local function IsIdentifierWhitelisted(source)
+    for _, identifier in pairs(GetPlayerIdentifiers(source)) do
+        if lib.table.contains(config.allowedIdentifiers, identifier) then
+            return true
+        end
+    end
+    return false
+end
+
+function Utils.IsWhitelisted(source)
+    return (
+        IsIdentifierWhitelisted(source) or
+        IsPlayerAceAllowed(source, 'lockdown.bypass') or
+        IsDiscordWhitelisted(source)
+    )
+end
+
+return Utils


### PR DESCRIPTION
Added some improvements as seen on the showcase post for the resource featured on Overextends discord.

Added:
- Discord role check for whitelisting
- Use any identifier
  - As long as it's formatted as on citizenfx, such as `discord:00000`, `live:000000`, `license:000aaa000`, etc...
- Added an option to either kick all users or just non whitelisted ones when the lockdown system all users

Changes:
- Moved whitelist function checks to utils file
- Changed process to reduce unnecessary code execution if server is open
- Altered the text in the config about identifiers